### PR TITLE
Make JLocalDateTime and JLocalTime pattern customisable

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
@@ -3,12 +3,7 @@ package com.ubertob.kondor.json.datetime
 import com.ubertob.kondor.json.JNumRepresentable
 import com.ubertob.kondor.json.JStringRepresentable
 import java.math.BigDecimal
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneId
+import java.time.*
 import java.time.format.DateTimeFormatter
 
 

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
@@ -3,7 +3,12 @@ package com.ubertob.kondor.json.datetime
 import com.ubertob.kondor.json.JNumRepresentable
 import com.ubertob.kondor.json.JStringRepresentable
 import java.math.BigDecimal
-import java.time.*
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 
@@ -20,6 +25,15 @@ object JLocalTime : JStringRepresentable<LocalTime>() {
 object JLocalDateTime : JStringRepresentable<LocalDateTime>() {
     override val cons: (String) -> LocalDateTime = LocalDateTime::parse
     override val render: (LocalDateTime) -> String = LocalDateTime::toString
+
+    fun withFormatter(formatter: DateTimeFormatter): JStringRepresentable<LocalDateTime> = Custom(formatter)
+
+    fun withPattern(pattern: String): JStringRepresentable<LocalDateTime> = Custom(DateTimeFormatter.ofPattern(pattern))
+
+    private class Custom(private val formatter: DateTimeFormatter) : JStringRepresentable<LocalDateTime>() {
+        override val cons: (String) -> LocalDateTime = { LocalDateTime.parse(it, formatter) }
+        override val render: (LocalDateTime) -> String = { formatter.format(it) }
+    }
 }
 
 object JDuration : JStringRepresentable<Duration>() {

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
@@ -20,6 +20,15 @@ object JZoneId : JStringRepresentable<ZoneId>() {
 object JLocalTime : JStringRepresentable<LocalTime>() {
     override val cons: (String) -> LocalTime = LocalTime::parse
     override val render: (LocalTime) -> String = LocalTime::toString
+
+    fun withFormatter(formatter: DateTimeFormatter): JStringRepresentable<LocalTime> = Custom(formatter)
+
+    fun withPattern(pattern: String): JStringRepresentable<LocalTime> = Custom(DateTimeFormatter.ofPattern(pattern))
+
+    private class Custom(private val formatter: DateTimeFormatter) : JStringRepresentable<LocalTime>() {
+        override val cons: (String) -> LocalTime = { LocalTime.parse(it, formatter) }
+        override val render: (LocalTime) -> String = { formatter.format(it) }
+    }
 }
 
 object JLocalDateTime : JStringRepresentable<LocalDateTime>() {

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/ShortFunctions.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/ShortFunctions.kt
@@ -11,6 +11,12 @@ fun <PT : Any> str(binder: PT.() -> LocalTime) = JField(binder, JLocalTime)
 @JvmName("bindLocalTimeNull")
 fun <PT : Any> str(binder: PT.() -> LocalTime?) = JFieldMaybe(binder, JLocalTime)
 
+@JvmName("bindLocalTimeWithPattern")
+fun <PT : Any> str(pattern: String, binder: PT.() -> LocalTime) = JField(binder, JLocalTime.withPattern(pattern))
+
+@JvmName("bindLocalTimeWithPatternNull")
+fun <PT : Any> str(pattern: String, binder: PT.() -> LocalTime?) = JFieldMaybe(binder, JLocalTime.withPattern(pattern))
+
 @JvmName("bindLocalDateTime")
 fun <PT : Any> str(binder: PT.() -> LocalDateTime) = JField(binder, JLocalDateTime)
 

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/ShortFunctions.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/ShortFunctions.kt
@@ -17,6 +17,12 @@ fun <PT : Any> str(binder: PT.() -> LocalDateTime) = JField(binder, JLocalDateTi
 @JvmName("bindLocalDateTimeNull")
 fun <PT : Any> str(binder: PT.() -> LocalDateTime?) = JFieldMaybe(binder, JLocalDateTime)
 
+@JvmName("bindLocalDateTimeWithPattern")
+fun <PT : Any> str(pattern: String, binder: PT.() -> LocalDateTime) = JField(binder, JLocalDateTime.withPattern(pattern))
+
+@JvmName("bindLocalDateTimeWithPatternNull")
+fun <PT : Any> str(pattern: String, binder: PT.() -> LocalDateTime?) = JFieldMaybe(binder, JLocalDateTime.withPattern(pattern))
+
 @JvmName("bindLocalDate")
 fun <PT : Any> str(binder: PT.() -> LocalDate) = JField(binder, JLocalDate)
 

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalDateTimeTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalDateTimeTest.kt
@@ -1,0 +1,128 @@
+package com.ubertob.kondor.json
+
+import com.ubertob.kondor.expectSuccess
+import com.ubertob.kondor.json.datetime.JLocalDateTime
+import com.ubertob.kondor.json.datetime.str
+import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.jsonnode.JsonNodeString
+import com.ubertob.kondor.json.jsonnode.NodePathRoot
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class JLocalDateTimeTest {
+    @Test
+    fun `Json LocalDateTime with custom format`() {
+        val date = LocalDateTime.of(2020, 10, 15, 14, 1, 34)
+        val format = DateTimeFormatter.ofPattern("dd/MM/yyyy hh:mm:ss a")
+        val jLocalDateTime = JLocalDateTime.withFormatter(format)
+
+        val dateTimeAsJsonNode = JsonNodeString("15/10/2020 02:01:34 pm", NodePathRoot)
+        expectThat(jLocalDateTime.toJsonNode(date, NodePathRoot)).isEqualTo(dateTimeAsJsonNode)
+        expectThat(jLocalDateTime.fromJsonNode(dateTimeAsJsonNode).expectSuccess()).isEqualTo(date)
+
+        val dateTimeAsString = "\"15/10/2020 02:01:34 pm\""
+        expectThat(jLocalDateTime.toJson(date)).isEqualTo(dateTimeAsString)
+        expectThat(jLocalDateTime.fromJson(dateTimeAsString).expectSuccess()).isEqualTo(date)
+    }
+
+    @Test
+    fun `Json LocalDateTime with custom format as String`() {
+        val dateTime = LocalDateTime.of(2020, 10, 15, 14, 1, 34)
+        val jLocalDateTime = JLocalDateTime.withPattern("dd/MM/yyyy hh:mm:ss a")
+
+        val dateTimeAsJsonNode = JsonNodeString("15/10/2020 02:01:34 pm", NodePathRoot)
+        expectThat(jLocalDateTime.toJsonNode(dateTime, NodePathRoot)).isEqualTo(dateTimeAsJsonNode)
+        expectThat(jLocalDateTime.fromJsonNode(dateTimeAsJsonNode).expectSuccess()).isEqualTo(dateTime)
+
+        val dateTimeAsString = "\"15/10/2020 02:01:34 pm\""
+        expectThat(jLocalDateTime.toJson(dateTime)).isEqualTo(dateTimeAsString)
+        expectThat(jLocalDateTime.fromJson(dateTimeAsString).expectSuccess()).isEqualTo(dateTime)
+    }
+
+    @Nested
+    inner class ShortFunctions {
+        @Test
+        fun `reads an object with date in a custom format`() {
+            val json =
+                // language=json
+                """
+                    {
+                      "id": "abcd",
+                      "date": "15/10/2020 02:01:34 pm"
+                    }
+                """.trimIndent()
+
+            val result = JTransaction.fromJson(json)
+
+            expectThat(result.expectSuccess().dateTime).isEqualTo(LocalDateTime.of(2020, 10, 15, 14, 1, 34))
+        }
+
+        @Nested
+        @DisplayName("reads an object with optional date")
+        inner class OptionalDate {
+            @Test
+            fun `date missing`() {
+                val json =
+                    // language=json
+                    """
+                        {
+                          "id": "abcd"
+                        }
+                    """.trimIndent()
+
+                val result = JTransactionWithOptionalDate.fromJson(json)
+
+                expectThat(result.expectSuccess().date).isEqualTo(null)
+            }
+
+            @Test
+            fun `date present`() {
+                val json =
+                    // language=json
+                    """
+                    {
+                      "id": "abcd",
+                      "date": "01/02/2021 02:15:56 am"
+                    }
+                """.trimIndent()
+
+                val result = JTransactionWithOptionalDate.fromJson(json)
+
+                expectThat(result.expectSuccess().date).isEqualTo(LocalDateTime.of(2021, 2, 1, 2, 15, 56))
+            }
+        }
+
+    }
+
+    data class Transaction(val id: String, val dateTime: LocalDateTime)
+
+    object JTransaction : JAny<Transaction>() {
+        private val id by str(Transaction::id)
+        private val date by str("dd/MM/yyyy hh:mm:ss a", Transaction::dateTime)
+
+        override fun JsonNodeObject.deserializeOrThrow(): Transaction =
+            Transaction(
+                id = +id,
+                dateTime = +date,
+            )
+    }
+
+    data class TransactionWithOptionalDateTime(val id: String, val date: LocalDateTime?)
+
+    object JTransactionWithOptionalDate : JAny<TransactionWithOptionalDateTime>() {
+        private val id by str(TransactionWithOptionalDateTime::id)
+        private val date by str("dd/MM/yyyy hh:mm:ss a", TransactionWithOptionalDateTime::date)
+
+        override fun JsonNodeObject.deserializeOrThrow(): TransactionWithOptionalDateTime =
+            TransactionWithOptionalDateTime(
+                id = +id,
+                date = +date,
+            )
+    }
+}
+

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalTimeTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalTimeTest.kt
@@ -1,0 +1,127 @@
+package com.ubertob.kondor.json
+
+import com.ubertob.kondor.expectSuccess
+import com.ubertob.kondor.json.datetime.JLocalTime
+import com.ubertob.kondor.json.datetime.str
+import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.jsonnode.JsonNodeString
+import com.ubertob.kondor.json.jsonnode.NodePathRoot
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+class JLocalTimeTest {
+    @Test
+    fun `Json LocalTime with custom format`() {
+        val time = LocalTime.of(14, 1, 34)
+        val format = DateTimeFormatter.ofPattern("hh:mm:ss a")
+        val jLocalTime = JLocalTime.withFormatter(format)
+
+        val timeAsJsonNode = JsonNodeString("02:01:34 pm", NodePathRoot)
+        expectThat(jLocalTime.toJsonNode(time, NodePathRoot)).isEqualTo(timeAsJsonNode)
+        expectThat(jLocalTime.fromJsonNode(timeAsJsonNode).expectSuccess()).isEqualTo(time)
+
+        val timeAsString = "\"02:01:34 pm\""
+        expectThat(jLocalTime.toJson(time)).isEqualTo(timeAsString)
+        expectThat(jLocalTime.fromJson(timeAsString).expectSuccess()).isEqualTo(time)
+    }
+
+    @Test
+    fun `Json LocalTime with custom format as String`() {
+        val time = LocalTime.of(14, 1, 34)
+        val jLocalTime = JLocalTime.withPattern("hh:mm:ss a")
+
+        val timeAsJsonNode = JsonNodeString("02:01:34 pm", NodePathRoot)
+        expectThat(jLocalTime.toJsonNode(time, NodePathRoot)).isEqualTo(timeAsJsonNode)
+        expectThat(jLocalTime.fromJsonNode(timeAsJsonNode).expectSuccess()).isEqualTo(time)
+
+        val timeAsString = "\"02:01:34 pm\""
+        expectThat(jLocalTime.toJson(time)).isEqualTo(timeAsString)
+        expectThat(jLocalTime.fromJson(timeAsString).expectSuccess()).isEqualTo(time)
+    }
+
+    @Nested
+    inner class ShortFunctions {
+        @Test
+        fun `reads an object with time in a custom format`() {
+            val json =
+                // language=json
+                """
+                    {
+                      "id": "abcd",
+                      "time": "02:01:34 pm"
+                    }
+                """.trimIndent()
+
+            val result = JTransaction.fromJson(json)
+
+            expectThat(result.expectSuccess().time).isEqualTo(LocalTime.of(14, 1, 34))
+        }
+
+        @Nested
+        @DisplayName("reads an object with optional time")
+        inner class OptionalTime {
+            @Test
+            fun `time missing`() {
+                val json =
+                    // language=json
+                    """
+                        {
+                          "id": "abcd"
+                        }
+                    """.trimIndent()
+
+                val result = JTransactionWithOptionalTime.fromJson(json)
+
+                expectThat(result.expectSuccess().time).isEqualTo(null)
+            }
+
+            @Test
+            fun `time present`() {
+                val json =
+                    // language=json
+                    """
+                    {
+                      "id": "abcd",
+                      "time": "02:15:56 am"
+                    }
+                """.trimIndent()
+
+                val result = JTransactionWithOptionalTime.fromJson(json)
+
+                expectThat(result.expectSuccess().time).isEqualTo(LocalTime.of(2, 15, 56))
+            }
+        }
+
+    }
+
+    data class Transaction(val id: String, val time: LocalTime)
+
+    object JTransaction : JAny<Transaction>() {
+        private val id by str(Transaction::id)
+        private val time by str("hh:mm:ss a", Transaction::time)
+
+        override fun JsonNodeObject.deserializeOrThrow(): Transaction =
+            Transaction(
+                id = +id,
+                time = +time,
+            )
+    }
+
+    data class TransactionWithOptionalTime(val id: String, val time: LocalTime?)
+
+    object JTransactionWithOptionalTime : JAny<TransactionWithOptionalTime>() {
+        private val id by str(TransactionWithOptionalTime::id)
+        private val time by str("hh:mm:ss a", TransactionWithOptionalTime::time)
+
+        override fun JsonNodeObject.deserializeOrThrow(): TransactionWithOptionalTime =
+            TransactionWithOptionalTime(
+                id = +id,
+                time = +time,
+            )
+    }
+}


### PR DESCRIPTION
Following #5 , we can probably do the same for `JLocalDateTime` and `JLocalTime`.