### PR TITLE
Allow JMap to be generic on both Key and Value

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JAny.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JAny.kt
@@ -71,6 +71,9 @@ class JMap<K : Any, V : Any>(
     private val keyConverter: JsonConverter<K, JsonNodeString>,
     private val valueConverter: JConverter<V>
 ) : ObjectNodeConverter<Map<K, V>>() {
+    companion object {
+        operator fun <V: Any> invoke(valueConverter: JConverter<V>): JMap<String, V> = JMap(JString, valueConverter)
+    }
 
     override fun JsonNodeObject.deserializeOrThrow() =
         fieldMap.entries.associate { (key, value) ->
@@ -94,6 +97,3 @@ class JMap<K : Any, V : Any>(
             }
 
 }
-
-@Suppress("FunctionName") //Using capital function for backwards compatibility
-fun <V : Any> JMap(valueConverter: JConverter<V>): JMap<String, V> = JMap(JString, valueConverter)

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/DomainExample.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/DomainExample.kt
@@ -50,6 +50,10 @@ fun randomNotes() = Notes(
     thingsToDo = randomList(0, 10) { randomString(uppercase, 3, 3) to randomString(lowercase, 1, 20) }.toMap()
 )
 
+fun randomTaskId(): TaskId = UUID.randomUUID().toString().let(::TaskId)
+fun randomTask(): Task = Task(randomString(uppercase, 3, 10), randomString(lowercase, 1, 20))
+fun randomTasks(): Map<TaskId, Task> = randomList(0, 10) { randomTaskId() to randomTask() }.toMap()
+
 private fun randomPath() =
     randomList(1, 10, { randomString(lowercase, 3, 10) }).joinToString(separator = "/", prefix = "/")
 
@@ -214,6 +218,27 @@ object JNotes : JAny<Notes>() {
         )
 }
 
+data class TaskId(val value: String)
+object JTaskId: JStringRepresentable<TaskId>() {
+    override val cons: (String) -> TaskId = ::TaskId
+    override val render: (TaskId) -> String = TaskId::value
+
+}
+
+data class Task(val name: String, val description: String)
+object JTask: JAny<Task>() {
+    private val name by str(Task::name)
+    private val description by str(Task::description)
+
+    override fun JsonNodeObject.deserializeOrThrow() =
+        Task(
+            name = +name,
+            description = +description
+        )
+}
+
+val JTasks: JMap<TaskId, Task> = JMap(JTaskId, JTask)
+
 
 class Products : ArrayList<Product>() {
     fun total(): Double = sumOf { it.price ?: 0.0 }
@@ -267,6 +292,3 @@ object JSelectedFile : JAny<SelectedFile>() {
         )
 
 }
-
-
-

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesExtraTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesExtraTest.kt
@@ -88,6 +88,23 @@ class JValuesExtraTest {
     }
 
     @Test
+    fun `Json Tasks`() {
+        repeat(10) {
+            val value = randomTasks()
+
+            val json = JTasks.toJsonNode(value, NodePathRoot)
+
+            val actual = JTasks.fromJsonNode(json).expectSuccess()
+
+            expectThat(actual).isEqualTo(value)
+
+            val jsonStr = JTasks.toPrettyJson(value)
+
+            expectThat(JTasks.fromJson(jsonStr).expectSuccess()).isEqualTo(value)
+        }
+    }
+
+    @Test
     fun `Json Products`() {
 
         repeat(10) {

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonSchemaTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonSchemaTest.kt
@@ -159,6 +159,17 @@ class JsonSchemaTest {
         )
     }
 
+    @Test
+    fun `schema for non-string keyed object map`() {
+        val schema = JTasks.schema().pretty()
+
+        expectThat(schema).isEqualTo(
+            """{
+              |  "type": "object"
+              |}""".trimMargin()
+        )
+    }
+
 
     @Test
     fun `schema for a flattened object`() {


### PR DESCRIPTION
This will be especially useful for creating ObjectNodeConverters where the keys are tiny typed domain string wrappers.