### PR TITLE
Do not double quote keys in JMap

### DIFF
--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesExtraTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesExtraTest.kt
@@ -105,6 +105,22 @@ class JValuesExtraTest {
     }
 
     @Test
+    fun `JMaps without a specified keyConverter do not double quote`() {
+        val map = mapOf(
+            "foo1" to "bar1",
+            "foo2" to "bar2"
+        )
+
+        expectThat(JMap(JString).toPrettyJson(map)).isEqualTo(
+            """{
+                |  "foo1": "bar1",
+                |  "foo2": "bar2"
+                |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
     fun `Json Products`() {
 
         repeat(10) {


### PR DESCRIPTION
Using JsonConverter<K, JsonNodeString>::toJson returns a string which begins and ends with a quote mark.

This resulted in an output of the form:

{
  "\"key1\"": "value1",
  "\"key2\"": "value2"
}

Changed the JMap to use the cons and render functions of a JStringRepresentable<K> instead to avoid this issue