### PR TITLE
Fix default locale

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/datetime/JDateTime.kt
@@ -5,7 +5,7 @@ import com.ubertob.kondor.json.JStringRepresentable
 import java.math.BigDecimal
 import java.time.*
 import java.time.format.DateTimeFormatter
-
+import java.util.Locale
 
 object JZoneId : JStringRepresentable<ZoneId>() {
     override val cons: (String) -> ZoneId = ZoneId::of
@@ -18,7 +18,8 @@ object JLocalTime : JStringRepresentable<LocalTime>() {
 
     fun withFormatter(formatter: DateTimeFormatter): JStringRepresentable<LocalTime> = Custom(formatter)
 
-    fun withPattern(pattern: String): JStringRepresentable<LocalTime> = Custom(DateTimeFormatter.ofPattern(pattern))
+    fun withPattern(pattern: String, locale: Locale = Locale.ENGLISH): JStringRepresentable<LocalTime> =
+        Custom(DateTimeFormatter.ofPattern(pattern).withLocale(locale))
 
     private class Custom(private val formatter: DateTimeFormatter) : JStringRepresentable<LocalTime>() {
         override val cons: (String) -> LocalTime = { LocalTime.parse(it, formatter) }
@@ -32,7 +33,8 @@ object JLocalDateTime : JStringRepresentable<LocalDateTime>() {
 
     fun withFormatter(formatter: DateTimeFormatter): JStringRepresentable<LocalDateTime> = Custom(formatter)
 
-    fun withPattern(pattern: String): JStringRepresentable<LocalDateTime> = Custom(DateTimeFormatter.ofPattern(pattern))
+    fun withPattern(pattern: String, locale: Locale = Locale.ENGLISH): JStringRepresentable<LocalDateTime> =
+        Custom(DateTimeFormatter.ofPattern(pattern).withLocale(locale))
 
     private class Custom(private val formatter: DateTimeFormatter) : JStringRepresentable<LocalDateTime>() {
         override val cons: (String) -> LocalDateTime = { LocalDateTime.parse(it, formatter) }
@@ -51,14 +53,14 @@ object JLocalDate : JStringRepresentable<LocalDate>() {
 
     fun withFormatter(formatter: DateTimeFormatter): JStringRepresentable<LocalDate> = Custom(formatter)
 
-    fun withPattern(pattern: String): JStringRepresentable<LocalDate> = Custom(DateTimeFormatter.ofPattern(pattern))
+    fun withPattern(pattern: String, locale: Locale = Locale.ENGLISH): JStringRepresentable<LocalDate> =
+        Custom(DateTimeFormatter.ofPattern(pattern).withLocale(locale))
 
     private class Custom(private val formatter: DateTimeFormatter) : JStringRepresentable<LocalDate>() {
         override val cons: (String) -> LocalDate = { LocalDate.parse(it, formatter) }
         override val render: (LocalDate) -> String = { formatter.format(it) }
     }
 }
-
 
 //instant as date string
 object JInstant : JStringRepresentable<Instant>() {
@@ -71,4 +73,3 @@ object JInstantEpoch : JNumRepresentable<Instant>() {
     override val cons: (BigDecimal) -> Instant = { Instant.ofEpochMilli(it.toLong()) }
     override val render: (Instant) -> BigDecimal = { it.toEpochMilli().toBigDecimal() }
 }
-

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalDateTimeTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalDateTimeTest.kt
@@ -18,13 +18,13 @@ import java.util.*
 
 class JLocalDateTimeTest {
     
-    val am = DateFormatSymbols(Locale.getDefault()).amPmStrings[0]
-    val pm = DateFormatSymbols(Locale.getDefault()).amPmStrings[1]
+    private val am = DateFormatSymbols(Locale.ENGLISH).amPmStrings[0]
+    private val pm = DateFormatSymbols(Locale.ENGLISH).amPmStrings[1]
     
     @Test
     fun `Json LocalDateTime with custom format`() {
         val date = LocalDateTime.of(2020, 10, 15, 14, 1, 34)
-        val format = DateTimeFormatter.ofPattern("dd/MM/yyyy hh:mm:ss a")
+        val format = DateTimeFormatter.ofPattern("dd/MM/yyyy hh:mm:ss a").withLocale(Locale.ENGLISH)
         val jLocalDateTime = JLocalDateTime.withFormatter(format)
 
         val dateTimeAsJsonNode = JsonNodeString("15/10/2020 02:01:34 $pm", NodePathRoot)

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalTimeTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JLocalTimeTest.kt
@@ -13,12 +13,14 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class JLocalTimeTest {
+
     @Test
     fun `Json LocalTime with custom format`() {
         val time = LocalTime.of(14, 1, 34)
-        val format = DateTimeFormatter.ofPattern("hh:mm:ss a")
+        val format = DateTimeFormatter.ofPattern("hh:mm:ss a").withLocale(Locale.ENGLISH)
         val jLocalTime = JLocalTime.withFormatter(format)
 
         val timeAsJsonNode = JsonNodeString("02:01:34 PM", NodePathRoot)


### PR DESCRIPTION
The following tests were failing on my machine due to a different `Locale`

```
JLocalTimeTest > Json LocalTime with custom format as String() FAILED
    strikt.internal.opentest4j.AssertionFailed at JLocalTimeTest.kt:39

JLocalTimeTest > Json LocalTime with custom format() FAILED
    strikt.internal.opentest4j.AssertionFailed at JLocalTimeTest.kt:25

JLocalTimeTest > ShortFunctions > reads an object with time in a custom format() FAILED
    org.opentest4j.AssertionFailedError at JLocalTimeTest.kt:62

JLocalTimeTest > ShortFunctions > reads an object with optional time > time present() FAILED
    org.opentest4j.AssertionFailedError at JLocalTimeTest.kt:96
```

---

Changes:
* allow specifying a `Locale` in `withPattern` with a default
* fix tests
* remove extra lines