### PR TITLE
VersionedConverter<T> and VersionMapConverter<T>

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/VersionedConverter.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/VersionedConverter.kt
@@ -1,0 +1,71 @@
+package com.ubertob.kondor.json
+
+import com.ubertob.kondor.json.JsonStyle.Companion.appendText
+import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.jsonnode.JsonNodeString
+import com.ubertob.kondor.json.jsonnode.NodePath
+import com.ubertob.kondor.json.jsonnode.asStringValue
+import com.ubertob.kondor.outcome.asFailure
+import com.ubertob.kondor.outcome.asSuccess
+import com.ubertob.kondor.outcome.bind
+import com.ubertob.kondor.outcome.failIfNull
+
+
+private const val defaultVersionProperty = "@version"
+
+
+abstract class VersionedConverter<T : Any> : ObjectNodeConverter<T> {
+    open val versionProperty = defaultVersionProperty
+    open val defaultVersion: String? = null
+    
+    abstract fun converterForVersion(version: String): ObjectNodeConverter<T>?
+    
+    abstract val outputVersion: String
+    
+    open val outputVersionConverter: ObjectNodeConverter<T> get() =
+        converterForVersion(outputVersion) ?: error("no converter for version $outputVersion")
+    
+    override fun fromJsonNode(node: JsonNodeObject): JsonOutcome<T> {
+        val jsonVersion = node._fieldMap[versionProperty].asStringValue()
+            ?: defaultVersion
+            ?: return missingVersionError(node).asFailure()
+        
+        return converterForVersion(jsonVersion).asSuccess()
+            .failIfNull { unsupportedVersionError(node, jsonVersion) }
+            .bind { it.fromJsonNode(node) }
+    }
+    
+    override fun fieldAppenders(valueObject: T): List<NamedAppender> {
+        return outputVersionConverter.fieldAppenders(valueObject) +
+            (versionProperty to { s, _ ->
+                s.appendValueSeparator(this)
+                appendText(outputVersion)
+                this
+            })
+    }
+    
+    override fun toJsonNode(value: T, path: NodePath): JsonNodeObject =
+        outputVersionConverter.toJsonNode(value, path).let {
+            it.copy(_fieldMap = it._fieldMap + (versionProperty to JsonNodeString(outputVersion, path + versionProperty)))
+        }
+    
+    private fun missingVersionError(node: JsonNodeObject) =
+        JsonPropertyError(
+            node._path,
+            versionProperty, "missing $versionProperty property"
+        )
+    
+    private fun unsupportedVersionError(node: JsonNodeObject, version: String) =
+        JsonPropertyError(node._path + versionProperty, versionProperty, "unsupported format version $version")
+}
+
+
+data class VersionMapConverter<T: Any>(
+    override val versionProperty: String = defaultVersionProperty,
+    override val defaultVersion: String? = null,
+    val versionConverters: Map<String,ObjectNodeConverter<T>>,
+    override val outputVersion: String = versionConverters.keys.max()
+) : VersionedConverter<T>() {
+    override fun converterForVersion(version: String): ObjectNodeConverter<T>? =
+        versionConverters[version]
+}

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/VersionedConverterTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/VersionedConverterTest.kt
@@ -1,0 +1,96 @@
+package com.ubertob.kondor.json
+
+import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.jsonnode.NodePathRoot
+import com.ubertob.kondortools.expectFailure
+import com.ubertob.kondortools.expectSuccess
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+
+private data class Example(
+    val i: Int,
+    val s: String
+)
+
+private object V1Format : JAny<Example>() {
+    val i by num(Example::i)
+    val s by str(Example::s)
+    
+    override fun JsonNodeObject.deserializeOrThrow(): Example =
+        Example(i = +i, s = +s)
+}
+
+private object V2Format : JAny<Example>() {
+    val int by num(Example::i)
+    val str by str(Example::s)
+    
+    override fun JsonNodeObject.deserializeOrThrow(): Example =
+        Example(i = +int, s = +str)
+}
+
+private val converterWithMandatoryVersionField = VersionMapConverter(
+    versionConverters = mapOf("1" to V1Format, "2" to V2Format)
+)
+
+private val converterWithDefaultVersion = VersionMapConverter(
+    versionConverters = mapOf("1" to V1Format, "2" to V2Format),
+    defaultVersion = "1"
+)
+
+
+class VersionedConverterTest {
+    companion object {
+        val testStyle = JsonStyle.compact.copy(sortedObjectFields = true)
+    }
+    
+    @Test
+    fun `reads multiple versions, writes one version`() {
+        val converter = converterWithMandatoryVersionField
+        
+        val original = Example(2, "eyes")
+        
+        val v1Json = """{"@version":"1","i":2,"s":"eyes"}"""
+        val v2Json = """{"@version":"2","int":2,"str":"eyes"}"""
+        
+        assertEquals(original, converter.fromJson(v1Json).expectSuccess())
+        assertEquals(original, converter.fromJson(v2Json).expectSuccess())
+        
+        val generatedJson = converter.toJson(original, testStyle)
+        assertEquals(v2Json, generatedJson)
+    }
+    
+    @Test
+    fun `fails when mandatory version is missing`() {
+        val converter = converterWithMandatoryVersionField
+        
+        val jsonWithoutSpecificVersion = """{"i":3,"s":"amigos"}"""
+        
+        val failure = converter.fromJson(jsonWithoutSpecificVersion).expectFailure() as JsonPropertyError
+        assertEquals(NodePathRoot, failure.path)
+        assertEquals(converter.versionProperty, failure.propertyName)
+    }
+    
+    @Test
+    fun `can use default version if not specified in the json`() {
+        val converter = converterWithDefaultVersion
+        
+        val badJson = """{"i":3,"s":"amigos"}"""
+        
+        val parsed = converter.fromJson(badJson).expectSuccess()
+        assertEquals((Example(3, "amigos")), parsed)
+    }
+    
+    @Test
+    fun `generates json node equivalent to json text`() {
+        val converter = converterWithMandatoryVersionField
+        val original = Example(4, "seasons")
+        
+        val directJson =
+            converter.toJson(original, testStyle)
+        val jsonFromJsonNode =
+            JJsonNode.toJson(converter.toJsonNode(original, NodePathRoot), testStyle)
+        
+        assertEquals(directJson, jsonFromJsonNode)
+    }
+}


### PR DESCRIPTION
A VersionedConverter lets you map different JSON format versions to the same domain model, using a property in the JSON to identify the format version.

A VersionMapConverter is a convenient way to create VersionedConverter from a map of version ID to converter.
