### PR TITLE
Added Float converter and `num` accepts JNumRepresentable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ rationale when appropriate:
 ### v.3.1.0 - 
 
 Kondor-mongo: fromBsonDoc return an Outcome error instead of nullable for better errors
+Kondor-core: added JFloat to support Float values
+Kondor-core: num accepts custom JNumRepresentable
 
 ### v.3.0.0 - 31 May 2024
 

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JDataClass.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JDataClass.kt
@@ -99,9 +99,10 @@ abstract class JDataClassReflect<T : Any>(val klazz: KClass<T>) : JDataClass<T>(
             println("-")
 
             val converter: JsonConverter<out Comparable<*>, out JsonNode> = when (fieldType) {
-               Int::class.java, Integer::class.java ->  JInt
+                Int::class.java, Integer::class.java ->  JInt
                 Long::class.java -> JLong
-                Float::class.java, Double::class.java -> JDouble
+                Float::class.java -> JFloat
+                Double::class.java -> JDouble
                 String::class.java -> JString
                 Boolean::class.java -> JBoolean
                 else -> fieldType.classLoader.loadClass("J${fieldType.simpleName}") as JsonConverter<out Comparable<*>, out JsonNode> //how to get the object from a javaclass or get a Koltin class by name??!!!

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JValues.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JValues.kt
@@ -36,8 +36,17 @@ object JString : JStringRepresentable<String>() {
         app.appendText(value)
 }
 
-object JDouble : JNumRepresentable<Double>() {
+object JFloat : JNumRepresentable<Float>() {
+    override val cons: (Number) -> Float = Number::toFloat
+    override val render: (Float) -> Number = { it }
+    override fun appendValue(app: CharWriter, style: JsonStyle, offset: Int, value: Float): CharWriter =
+        if (value.isFinite())
+            app.appendNumber(value)
+        else
+            app.appendText(value.toString())
+}
 
+object JDouble : JNumRepresentable<Double>() {
     override val cons: (Number) -> Double = Number::toDouble
     override val render: (Double) -> Number = Double::toBigDecimal
     override fun appendValue(app: CharWriter, style: JsonStyle, offset: Int, value: Double): CharWriter =
@@ -46,7 +55,6 @@ object JDouble : JNumRepresentable<Double>() {
         else
             app.appendText(value.toString())
 }
-
 
 object JInt : JNumRepresentable<Int>() {
     override val cons: (Number) -> Int = { num ->

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/ShortFunctions.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/ShortFunctions.kt
@@ -13,6 +13,12 @@ fun <PT : Any> bool(binder: PT.() -> Boolean) = JField(binder, JBoolean)
 fun <PT : Any> bool(binder: PT.() -> Boolean?) = JFieldMaybe(binder, JBoolean)
 
 
+@JvmName("bindNum")
+fun <PT : Any, T : Any> num(converter: JNumRepresentable<T>, binder: PT.() -> T) = JField(binder, converter)
+
+@JvmName("bindNumNull")
+fun <PT : Any, T : Any> num(converter: JNumRepresentable<T>, binder: PT.() -> T?) = JFieldMaybe(binder, converter)
+
 @JvmName("bindInt")
 fun <PT : Any> num(binder: PT.() -> Int) = JField(binder, JInt)
 

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JValuesTest.kt
@@ -63,6 +63,20 @@ class JValuesTest {
     }
 
     @Test
+    fun `Json Float`() {
+        repeat(10) {
+            val value = Random.nextFloat()
+
+            val json = JFloat.toJsonNode(value)
+            val actual = JFloat.fromJsonNode(json, NodePathRoot).expectSuccess()
+            expectThat(actual).isEqualTo(value)
+
+            val jsonStr = JFloat.toJson(value)
+            expectThat(JFloat.fromJson(jsonStr).expectSuccess()).isEqualTo(value)
+        }
+    }
+
+    @Test
     fun `Json Double`() {
         repeat(10) {
 

--- a/kondor-examples/src/jmh/kotlin/com/ubertob/kondor/json/jmh/DemoClass.kt
+++ b/kondor-examples/src/jmh/kotlin/com/ubertob/kondor/json/jmh/DemoClass.kt
@@ -5,6 +5,7 @@ import kotlin.random.Random
 data class DemoClass(
     val text: String,
     val boolean: Boolean,
+    val float: Float,
     val double: Double,
     val nullableInt: Int?,
     val array: List<String>
@@ -13,6 +14,7 @@ data class DemoClass(
         fun random() = DemoClass(
             text = randomString(),
             boolean = Random.nextBoolean(),
+            float = Random.nextFloat(),
             double = Random.nextDouble(),
             nullableInt = if (Random.nextBoolean()) Random.nextInt() else null,
             array = (1..Random.nextInt(5, 20)).map { randomString() }.toList()

--- a/kondor-examples/src/jmh/kotlin/com/ubertob/kondor/json/jmh/KondorConverters.kt
+++ b/kondor-examples/src/jmh/kotlin/com/ubertob/kondor/json/jmh/KondorConverters.kt
@@ -8,6 +8,7 @@ object JDemoClass : JAny<DemoClass>() {
     val text by str(DemoClass::text)
     val boolean by bool(DemoClass::boolean)
     val nullableInt by num(DemoClass::nullableInt)
+    val float by num(DemoClass::float)
     val double by num(DemoClass::double)
     val array by array(DemoClass::array)
 
@@ -16,6 +17,7 @@ object JDemoClass : JAny<DemoClass>() {
             text = +text,
             boolean = +boolean,
             nullableInt = +nullableInt,
+            float = +float,
             double = +double,
             array = +array
         )


### PR DESCRIPTION
Kondor lacks the support of `Kotlin.Float` values. As I tried to do it on my own in my project with a `JNumRepresentable`, `num` failed, so I've added support for that too :slightly_smiling_face: 