### PR TITLE
capture throws in the cons of JRepresentables and turn them into Failures

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JValues.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JValues.kt
@@ -8,10 +8,7 @@ import com.ubertob.kondor.json.parser.TokensStream
 import com.ubertob.kondor.json.parser.parseBoolean
 import com.ubertob.kondor.json.parser.parseNumber
 import com.ubertob.kondor.json.parser.parseString
-import com.ubertob.kondor.outcome.Outcome
-import com.ubertob.kondor.outcome.OutcomeException
-import com.ubertob.kondor.outcome.asFailure
-import com.ubertob.kondor.outcome.asSuccess
+import com.ubertob.kondor.outcome.*
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -32,7 +29,7 @@ abstract class JBooleanRepresentable<T : Any>() : JsonConverter<T, JsonNodeBoole
 
     override fun fromTokens(tokens: TokensStream, path: NodePath): JsonOutcome<T> =
         parseBoolean(tokens, path)
-            .transform { cons(it) }
+            .bind { str -> Outcome.tryOrFail { cons(str) }.transformFailure { err -> ConverterJsonError(path, err.msg) } }
 }
 
 object JBoolean : JBooleanRepresentable<Boolean>() {
@@ -201,7 +198,7 @@ abstract class JNumRepresentable<NUM : Number, T : Any>() : JsonConverter<T, Jso
 
     override fun fromTokens(tokens: TokensStream, path: NodePath): JsonOutcome<T> =
         parseNumber(tokens, path, safelyParse(path))
-            .transform { cons(it) }
+            .bind { str -> Outcome.tryOrFail { cons(str) }.transformFailure { err -> ConverterJsonError(path, err.msg) } }
 
     private fun safelyParse(path: NodePath): (String) -> JsonOutcome<NUM> = { numAsStr ->
         tryWithPath(path) {
@@ -240,6 +237,6 @@ abstract class JStringRepresentable<T>() : JsonConverter<T, JsonNodeString> {
 
     override fun fromTokens(tokens: TokensStream, path: NodePath): JsonOutcome<T> =
         parseString(tokens, path, true)
-            .transform { cons(it) }
+            .bind { str -> Outcome.tryOrFail { cons(str) }.transformFailure { err -> ConverterJsonError(path, err.msg) } }
 }
 

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JRepresentable.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JRepresentable.kt
@@ -1,0 +1,76 @@
+package com.ubertob.kondor.json
+
+import com.ubertob.kondor.json.jsonnode.NodePathRoot
+import com.ubertob.kondor.outcome.Failure
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+class JRepresentableTest {
+    object JStringGoesBoom : JStringRepresentable<String>() {
+        override val cons: (String) -> String = { throw IllegalArgumentException("boom")}
+        override val render: (String) -> String = { it }
+    }
+
+    object JIntGoesBoom : JIntRepresentable<String>() {
+        override val cons: (Int) -> String = { throw IllegalArgumentException("boom")}
+        override val render: (String) -> Int = { 1 }
+    }
+
+    object JBoolGoesBoom : JBooleanRepresentable<String>() {
+        override val cons: (Boolean) -> String = { throw IllegalArgumentException("boom")}
+        override val render: (String) -> Boolean = { true }
+    }
+
+    @Test
+    fun `errors thrown in the constructor function for JStringRepresentable are captured as Outcomes`() {
+        val json = "\"a-string\""
+
+        val outcome = JStringGoesBoom.fromJson(json)
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.reason }
+            .isEqualTo("boom")
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.path }
+            .isEqualTo(NodePathRoot)
+    }
+
+    @Test
+    fun `errors thrown in the constructor function for JNumberRepresentable are captured as Outcomes`() {
+        val json = "1"
+
+        val outcome = JIntGoesBoom.fromJson(json)
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.reason }
+            .isEqualTo("boom")
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.path }
+            .isEqualTo(NodePathRoot)
+    }
+
+    @Test
+    fun `errors thrown in the constructor function for JBooleanRepresentable are captured as Outcomes`() {
+        val json = "true"
+
+        val outcome = JBoolGoesBoom.fromJson(json)
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.reason }
+            .isEqualTo("boom")
+
+        expectThat(outcome)
+            .isA<Failure<JsonError>>()
+            .get { error.path }
+            .isEqualTo(NodePathRoot)
+    }
+}


### PR DESCRIPTION
Hey @uberto - spotted this tonight when I was working on some migration stuff.

I think this is the way it should work, but lmk if I'm doing it wrong!