### PR TITLE
Support escaped solidor characters in string values

### DIFF
--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/JsonLexer.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/JsonLexer.kt
@@ -87,6 +87,7 @@ class JsonLexerLazy(val inputStream: InputStream) {
 
                         Escaping -> when (char) {
                             '\\' -> currToken.write('\\')
+                            '/' -> currToken.write('/')
                             '"' -> currToken.write('\"')
                             'n' -> currToken.write('\n')
                             'f' -> currToken.write('\t')

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/KondorToken.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/KondorToken.kt
@@ -15,14 +15,14 @@ sealed class Separator(val sep: KondorSeparator) : KondorToken() {
     override val desc: String = sep.name
 }
 
-object ColonSep : Separator(KondorSeparator.Colon)
-object CommaSep : Separator(KondorSeparator.Comma)
-object OpeningBracketSep : Separator(KondorSeparator.OpeningBracket)
-object OpeningCurlySep : Separator(KondorSeparator.OpeningCurly)
-object OpeningQuotesSep : Separator(KondorSeparator.OpeningQuotes)
-object ClosingBracketSep : Separator(KondorSeparator.ClosingBracket)
-object ClosingCurlySep : Separator(KondorSeparator.ClosingCurly)
-object ClosingQuotesSep : Separator(KondorSeparator.ClosingQuotes)
+data object ColonSep : Separator(KondorSeparator.Colon)
+data object CommaSep : Separator(KondorSeparator.Comma)
+data object OpeningBracketSep : Separator(KondorSeparator.OpeningBracket)
+data object OpeningCurlySep : Separator(KondorSeparator.OpeningCurly)
+data object OpeningQuotesSep : Separator(KondorSeparator.OpeningQuotes)
+data object ClosingBracketSep : Separator(KondorSeparator.ClosingBracket)
+data object ClosingCurlySep : Separator(KondorSeparator.ClosingCurly)
+data object ClosingQuotesSep : Separator(KondorSeparator.ClosingQuotes)
 
 
 data class Value(val text: String, val pos: Int) : KondorToken() {

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonLexerTestAbstract.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonLexerTestAbstract.kt
@@ -89,7 +89,7 @@ abstract class JsonLexerTestAbstract {
     @Test
     fun `json strings with escapes`() {
         val json = """
-            {"abc":"abc\"\\ \n}"}
+            {"abc":"abc\"\\ \n\/}"}
         """.trimIndent()
         val tokens = tokenize(json).expectSuccess()
 
@@ -101,7 +101,7 @@ abstract class JsonLexerTestAbstract {
                 ClosingQuotesSep,
                 ColonSep,
                 OpeningQuotesSep,
-                Value("abc\"\\ \n}", 12),
+                Value("abc\"\\ \n/}", 13),
                 ClosingQuotesSep,
                 ClosingCurlySep
             )


### PR DESCRIPTION
E.g. "x\/y" in JSON source should be parsed as a string value "x/y"