### PR TITLE
Simplify lexer interface, improve error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This list is not currently intended to be all-encompassing - it will document major and breaking API changes with their
 rationale when appropriate:
 
+### v.4.0.0-beta2 - 16 October 2025
+
+Kondor-core: Error messages now report line and column numbers instead of character position for easier debugging
+
 ### v.3.5.2 - 7 May 2025
 
 Kondor-core: Solidus escaped as Json standard (Thanks Nat Pryce)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Another advantage of converters is that it's very easy to define different conve
 Moreover the converters have all the informations to produce very friendly and precise error messages:
 
 ```
-error at parsing: Expected a Double at position 55 but found '"' while parsing </items/0/price>
+error at parsing: Expected a Double at line 1, column 55 but found '"' while parsing </items/0/price>
 ```
 
 Finally converters know how to generate a Json schema, for example:

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JsonConverter.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/JsonConverter.kt
@@ -87,13 +87,15 @@ interface JsonConverter<T, JN : JsonNode> : Profunctor<T, T>,
     private fun fromTokensExhaustive(tokens: TokensStream): JsonOutcome<T> =
         fromTokens(tokens, NodePathRoot)
             .failIf({ tokens.hasNext() }) {
-                parsingError("EOF", tokens.next(), tokens.lastPosRead(), NodePathRoot, "json continue after end")
+                val token = tokens.next()
+                parsingError("EOF", token, NodePathRoot, "json continue after end")
             }
 
     fun T.checkForJsonTail(tokens: TokensStream) = //TODO remove it after replacing with FailIf everywhere
-        if (tokens.hasNext())
-            parsingFailure("EOF", tokens.next(), tokens.lastPosRead(), NodePathRoot, "json continue after end")
-        else
+        if (tokens.hasNext()) {
+            val token = tokens.next()
+            parsingFailure("EOF", token, NodePathRoot, "json continue after end")
+        } else
             asSuccess()
 
     fun appendValue(app: CharWriter, style: JsonStyle, offset: Int, value: T): CharWriter

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/jsonnode/JsonNode.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/jsonnode/JsonNode.kt
@@ -4,6 +4,7 @@ import com.ubertob.kondor.json.JsonError
 import com.ubertob.kondor.json.JsonParsingException
 import com.ubertob.kondor.json.JsonProperty
 import com.ubertob.kondor.json.parser.JsonLexerEager
+import com.ubertob.kondor.json.parser.Location
 import com.ubertob.kondor.json.parser.parseNewNode
 import com.ubertob.kondor.json.parser.parsingFailure
 import com.ubertob.kondor.outcome.Outcome
@@ -71,7 +72,7 @@ interface FieldsValues {
 
 fun parseJsonNode(jsonString: String): Outcome<JsonError, JsonNode> =
     if (jsonString.isEmpty())
-        parsingFailure("some valid Json", "end of file", 0, NodePathRoot, "invalid Json")
+        parsingFailure("some valid Json", Location(1, 1), NodePathRoot, "invalid Json")
     else
         JsonLexerEager(jsonString).tokenize()
 //    JsonLexerLazy(ByteArrayInputStream(jsonString.toByteArray())).tokenize()

--- a/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/KondorToken.kt
+++ b/kondor-core/src/main/kotlin/com/ubertob/kondor/json/parser/KondorToken.kt
@@ -1,5 +1,9 @@
 package com.ubertob.kondor.json.parser
 
+data class Location(val line: Int, val column: Int) {
+    override fun toString(): String = "line $line, column $column"
+}
+
 enum class KondorSeparator(val sign: Char) {
     Colon(':'), Comma(','), OpeningBracket('['), OpeningCurly('{'), OpeningQuotes('"'), ClosingBracket(']'), ClosingCurly(
         '}'
@@ -9,40 +13,28 @@ enum class KondorSeparator(val sign: Char) {
 
 sealed class KondorToken {
     abstract val desc: String //used for error messages
+    abstract val location: Location
 }
 
-sealed class Separator(val sep: KondorSeparator) : KondorToken() {
+sealed class Separator(val sep: KondorSeparator, override val location: Location) : KondorToken() {
     override val desc: String = sep.name
 }
 
-data object ColonSep : Separator(KondorSeparator.Colon)
-data object CommaSep : Separator(KondorSeparator.Comma)
-data object OpeningBracketSep : Separator(KondorSeparator.OpeningBracket)
-data object OpeningCurlySep : Separator(KondorSeparator.OpeningCurly)
-data object OpeningQuotesSep : Separator(KondorSeparator.OpeningQuotes)
-data object ClosingBracketSep : Separator(KondorSeparator.ClosingBracket)
-data object ClosingCurlySep : Separator(KondorSeparator.ClosingCurly)
-data object ClosingQuotesSep : Separator(KondorSeparator.ClosingQuotes)
+data class ColonSep(override val location: Location) : Separator(KondorSeparator.Colon, location)
+data class CommaSep(override val location: Location) : Separator(KondorSeparator.Comma, location)
+data class OpeningBracketSep(override val location: Location) : Separator(KondorSeparator.OpeningBracket, location)
+data class OpeningCurlySep(override val location: Location) : Separator(KondorSeparator.OpeningCurly, location)
+data class OpeningQuotesSep(override val location: Location) : Separator(KondorSeparator.OpeningQuotes, location)
+data class ClosingBracketSep(override val location: Location) : Separator(KondorSeparator.ClosingBracket, location)
+data class ClosingCurlySep(override val location: Location) : Separator(KondorSeparator.ClosingCurly, location)
+data class ClosingQuotesSep(override val location: Location) : Separator(KondorSeparator.ClosingQuotes, location)
 
 
-data class Value(val text: String, val pos: Int) : KondorToken() {
+data class Value(val text: String, override val location: Location) : KondorToken() {
     override val desc: String = "'$text'"
 }
 
 data class TokensStream(private val iterator: PeekingIterator<KondorToken>) :
     PeekingIterator<KondorToken> by iterator {
     fun toList(): List<KondorToken> = iterator.asSequence().toList()
-
-    private var currPos = 0
-
-    fun lastPosRead(): Int = currPos
-
-    override fun next(): KondorToken =
-        iterator.next().also {
-            currPos = when (it) {
-                is Separator -> currPos +1
-                is Value -> it.pos + it.text.length - 1
-            }
-        }
-
 }

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonLexerTestAbstract.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonLexerTestAbstract.kt
@@ -17,7 +17,7 @@ abstract class JsonLexerTestAbstract {
         val json = "abc"
         val tokensStream = tokenize(json).expectSuccess()
 
-        expectThat(tokensStream.toList()).isEqualTo(listOf(Value(json, 1)))
+        expectThat(tokensStream.toList()).isEqualTo(listOf(Value(json, Location(1, 1))))
     }
 
     @Test
@@ -27,12 +27,12 @@ abstract class JsonLexerTestAbstract {
 
         expectThat(tokens.toList()).isEqualTo(
             listOf(
-                Value("abc", 3),
-                Value("def", 9),
-                Value("gh", 13),
-                Value("ijk", 16),
-                Value("lmn", 21),
-                Value("opq", 28)
+                Value("abc", Location(1, 3)),
+                Value("def", Location(1, 9)),
+                Value("gh", Location(2, 1)),
+                Value("ijk", Location(2, 4)),
+                Value("lmn", Location(2, 9)),
+                Value("opq", Location(4, 2))
             )
         )
     }
@@ -44,26 +44,26 @@ abstract class JsonLexerTestAbstract {
 
         expectThat(tokens.toList()).isEqualTo(
             listOf(
-                OpeningBracketSep,
-                ClosingBracketSep,
-                OpeningCurlySep,
-                ClosingCurlySep,
-                ColonSep,
-                CommaSep,
-                OpeningQuotesSep,
-                ClosingQuotesSep,
-                OpeningBracketSep,
-                Value("a", 12),
-                CommaSep,
-                Value("b", 14),
-                CommaSep,
-                Value("c", 16),
-                ClosingBracketSep,
-                OpeningCurlySep,
-                Value("d", 21),
-                ColonSep,
-                Value("e", 23),
-                ClosingCurlySep
+                OpeningBracketSep(Location(1, 1)),
+                ClosingBracketSep(Location(1, 2)),
+                OpeningCurlySep(Location(1, 3)),
+                ClosingCurlySep(Location(1, 4)),
+                ColonSep(Location(1, 5)),
+                CommaSep(Location(1, 6)),
+                OpeningQuotesSep(Location(1, 8)),
+                ClosingQuotesSep(Location(1, 9)),
+                OpeningBracketSep(Location(1, 11)),
+                Value("a", Location(1, 12)),
+                CommaSep(Location(1, 13)),
+                Value("b", Location(1, 14)),
+                CommaSep(Location(1, 15)),
+                Value("c", Location(1, 16)),
+                ClosingBracketSep(Location(1, 17)),
+                OpeningCurlySep(Location(1, 20)),
+                Value("d", Location(1, 21)),
+                ColonSep(Location(1, 22)),
+                Value("e", Location(1, 23)),
+                ClosingCurlySep(Location(1, 24))
             )
         )
     }
@@ -77,13 +77,13 @@ abstract class JsonLexerTestAbstract {
 
         expectThat(tokens.toList()).isEqualTo(
             listOf(
-                OpeningCurlySep,
-                OpeningQuotesSep,
-                Value("abc", 4),
-                ClosingQuotesSep,
-                ColonSep,
-                Value("123", 10),
-                ClosingCurlySep
+                OpeningCurlySep(Location(1, 1)),
+                OpeningQuotesSep(Location(1, 3)),
+                Value("abc", Location(1, 4)),
+                ClosingQuotesSep(Location(1, 7)),
+                ColonSep(Location(1, 8)),
+                Value("123", Location(1, 10)),
+                ClosingCurlySep(Location(1, 13))
             )
         )
     }
@@ -97,15 +97,15 @@ abstract class JsonLexerTestAbstract {
 
         expectThat(tokens.toList()).isEqualTo(
             listOf(
-                OpeningCurlySep,
-                OpeningQuotesSep,
-                Value("abc", 3),
-                ClosingQuotesSep,
-                ColonSep,
-                OpeningQuotesSep,
-                Value("abc\"\\ \n/}", 13),
-                ClosingQuotesSep,
-                ClosingCurlySep
+                OpeningCurlySep(Location(1, 1)),
+                OpeningQuotesSep(Location(1, 2)),
+                Value("abc", Location(1, 3)),
+                ClosingQuotesSep(Location(1, 6)),
+                ColonSep(Location(1, 7)),
+                OpeningQuotesSep(Location(1, 8)),
+                Value("abc\"\\ \n/}", Location(1, 9)),
+                ClosingQuotesSep(Location(1, 22)),
+                ClosingCurlySep(Location(1, 23))
             )
         )
     }
@@ -120,9 +120,9 @@ abstract class JsonLexerTestAbstract {
 
         expectThat(tokens.toList()).isEqualTo(
             listOf(
-                OpeningQuotesSep,
-                Value("abc \u263A", 7),
-                ClosingQuotesSep,
+                OpeningQuotesSep(Location(1, 1)),
+                Value("abc \u263A", Location(1, 2)),
+                ClosingQuotesSep(Location(1, 12)),
             )
         )
     }

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonParserTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/JsonParserTest.kt
@@ -30,7 +30,6 @@ class JsonParserTest {
             val node = tokens.onRoot().parseJsonNodeBoolean().expectSuccess()
 
             expectThat(node.boolean).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
     }
 
@@ -60,7 +59,6 @@ class JsonParserTest {
             val node = tokens.onRoot().parseJsonNodeNum().expectSuccess()
 
             expectThat(node.num).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
 
         repeat(10) {
@@ -74,7 +72,6 @@ class JsonParserTest {
             val node = tokens.onRoot().parseJsonNodeNum().expectSuccess()
 
             expectThat(node.num).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
 
         repeat(10) {
@@ -90,7 +87,6 @@ class JsonParserTest {
             val node = tokens.onRoot().parseJsonNodeNum().expectSuccess()
 
             expectThat(node.num).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
 
         repeat(10) {
@@ -106,7 +102,6 @@ class JsonParserTest {
             val node = tokens.onRoot().parseJsonNodeNum().expectSuccess()
 
             expectThat(node.num).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
 
     }
@@ -123,7 +118,6 @@ class JsonParserTest {
         val node = tokens.onRoot().parseJsonNodeNum().expectSuccess()
 
         expectThat(node.num).isEqualTo(value)
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
 
@@ -139,7 +133,6 @@ class JsonParserTest {
         val node = tokens.onRoot().parseJsonNodeString().expectSuccess()
 
         expectThat(node.text).isEqualTo(value)
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -154,7 +147,6 @@ class JsonParserTest {
         val node = tokens.onRoot().parseJsonNodeString().expectSuccess()
 
         expectThat(node.text).isEqualTo(value)
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -173,7 +165,6 @@ class JsonParserTest {
 //            println("-> ${node.text}")
 
             expectThat(node.text).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
     }
 
@@ -193,7 +184,6 @@ class JsonParserTest {
 //            println("-> ${node.text}")
 
             expectThat(node.text).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
     }
 
@@ -213,7 +203,6 @@ class JsonParserTest {
 //            println("-> ${node.text}")
 
             expectThat(node.text).isEqualTo(value)
-            expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
         }
 
     }
@@ -227,7 +216,6 @@ class JsonParserTest {
 
         tokens.onRoot().parseJsonNodeNull().expectSuccess()
 
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
 
@@ -244,7 +232,6 @@ class JsonParserTest {
 
         expectThat(nodes.elements.count()).isEqualTo(3)
         expectThat(nodes.render()).isEqualTo("""["abc","def"]""")
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -257,7 +244,6 @@ class JsonParserTest {
         val nodes = tokens.onRoot().parseJsonNodeArray().expectSuccess()
 
         expectThat(nodes.render()).isEqualTo("[[],[]]")
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -271,7 +257,6 @@ class JsonParserTest {
 
         val expected = """{"id":123,"name":"Ann"}"""
         expectThat(nodes.render()).isEqualTo(expected)
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -284,7 +269,6 @@ class JsonParserTest {
         val nodes = tokens.onRoot().parseJsonNodeObject().expectSuccess()
 
         expectThat(nodes.render()).isEqualTo("{}")
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
     @Test
@@ -300,11 +284,8 @@ class JsonParserTest {
 
         val expected = """{"id":123,"name":"Ann"}"""
         expectThat(nodes.render()).isEqualTo(expected)
-        expectThat(lastPosRead(tokens)).isEqualTo(jsonString.length)
     }
 
-    private fun lastPosRead(tokens: TokensStream): Int =
-        tokens.lastPosRead()
 
     @Test
     fun `parse an object with JsonNode field`() {

--- a/kondor-core/src/test/kotlin/com/ubertob/kondor/json/ParserFailuresTest.kt
+++ b/kondor-core/src/test/kotlin/com/ubertob/kondor/json/ParserFailuresTest.kt
@@ -15,7 +15,7 @@ class ParserFailuresTest {
         val invalidJson = ""
         val error = parseJsonNode(invalidJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 0: expected some valid Json but found end of file - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 1: expected some valid Json but found end of file - invalid Json")
     }
 
     @Test
@@ -23,7 +23,7 @@ class ParserFailuresTest {
         val invalidJson = "BOOM"
         val error = parseJsonNode(invalidJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 0: expected a valid Number but found 'BOOM' - NumberFormatException For input string: \"BOOM\"")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 1: expected a valid Number but found 'BOOM' - NumberFormatException For input string: \"BOOM\"")
     }
 
 
@@ -32,7 +32,7 @@ class ParserFailuresTest {
         val invalidJson = ""
         val error = JPerson.fromJson(invalidJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 0: expected OpeningCurly but found end of file - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 0, column 0: expected OpeningCurly but found end of file - invalid Json")
     }
 
     @Test
@@ -41,7 +41,7 @@ class ParserFailuresTest {
 
         val error = JInt.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 5: expected EOF but found 'b' - json continue after end")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 5: expected EOF but found 'b' - json continue after end")
     }
 
     @Test
@@ -50,7 +50,7 @@ class ParserFailuresTest {
 
         val error = JBoolean.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 1: expected a Boolean but found 'False' - valid values: false, true")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 1: expected a Boolean but found 'False' - valid values: false, true")
     }
 
     @Test
@@ -71,7 +71,7 @@ class ParserFailuresTest {
         try {
             JBoolean.fromJson(illegalJson).orThrow()
         } catch (e: Exception) {
-            expectThat(e.message).isEqualTo("Error parsing node <[root]> at position 1: expected a Boolean but found 'False' - valid values: false, true")
+            expectThat(e.message).isEqualTo("Error parsing node <[root]> at line 1, column 1: expected a Boolean but found 'False' - valid values: false, true")
         }
     }
 
@@ -83,7 +83,7 @@ class ParserFailuresTest {
 
         val error = JString.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 16: expected ClosingQuotes but found end of file - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 2: expected ClosingQuotes but found end of file - invalid Json")
     }
 
     @Test
@@ -94,7 +94,7 @@ class ParserFailuresTest {
 
         val error = JString.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 7: expected a valid Json but found wrongly escaped char '\\ ' inside a Json string after 'foo ' - Invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 7: expected a valid Json but found wrongly escaped char '\\ ' inside a Json string after 'foo ' - Invalid Json")
     }
 
     @Test
@@ -162,7 +162,7 @@ class ParserFailuresTest {
 
         val error = JPerson.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 8: expected Colon but found '2' - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 8: expected Colon but found '2' - invalid Json")
     }
 
     @Test
@@ -171,7 +171,7 @@ class ParserFailuresTest {
 
         val error = JJsonNode.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 10: expected a valid key but found Comma - key missing in object field")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 11: expected a valid key but found Comma - key missing in object field")
     }
 
     @Test
@@ -180,7 +180,7 @@ class ParserFailuresTest {
 
         val error = JJsonNode.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 12: expected a valid key but found 'name' - key missing in object field")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 12: expected a valid key but found 'name' - key missing in object field")
     }
 
     @Test
@@ -198,7 +198,7 @@ class ParserFailuresTest {
         val jsonStringArray = JList(JString)
         val error = jsonStringArray.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node </[2]> at position 11: expected a new json value but found Comma - Comma in wrong position")
+        expectThat(error.msg).isEqualTo("Error parsing node </[2]> at line 1, column 12: expected a new json value but found Comma - Comma in wrong position")
 
     }
 
@@ -209,7 +209,7 @@ class ParserFailuresTest {
         val jsonStringArray = JList(JString)
         val error = jsonStringArray.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node </[0]> at position 1: expected a new json value but found Comma - Comma in wrong position")
+        expectThat(error.msg).isEqualTo("Error parsing node </[0]> at line 1, column 2: expected a new json value but found Comma - Comma in wrong position")
     }
 
     @Test
@@ -219,7 +219,7 @@ class ParserFailuresTest {
         val jsonStringArray = JList(JString)
         val error = jsonStringArray.fromJson(illegalJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 11: expected ClosingBracket but found ClosingCurly - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 12: expected ClosingBracket but found ClosingCurly - invalid Json")
     }
 
 
@@ -238,7 +238,7 @@ class ParserFailuresTest {
         val invalidJson = "BOOM"
         val error = JPerson.fromJson(invalidJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at position 1: expected OpeningCurly but found 'BOOM' - invalid Json")
+        expectThat(error.msg).isEqualTo("Error parsing node <[root]> at line 1, column 1: expected OpeningCurly but found 'BOOM' - invalid Json")
     }
 
     @Test
@@ -247,7 +247,7 @@ class ParserFailuresTest {
 
         val error = JJsonNode.fromJson(invalidJson).expectFailure()
 
-        expectThat(error.msg).isEqualTo("Error parsing node </obj/nestedObj> at position 38: expected a valid key but found 'BOOOM' - key missing in object field")
+        expectThat(error.msg).isEqualTo("Error parsing node </obj/nestedObj> at line 1, column 38: expected a valid key but found 'BOOOM' - key missing in object field")
     }
 
     @Test


### PR DESCRIPTION
Two improvements
- error messages now show line and column number, where previously they only had the char position in the stream
- simplify the lexer interface: tokens carry their own location in the input stream, so the TokenStream does not need to track position anymore